### PR TITLE
fix: Fix the issue with the use of the "defer" attribute on scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export interface CDNPluginOptions {
 
 import { defineConfig } from 'vite'
 
-import { cdn } from 'vite-pluginp-cdn2'
+import { cdn } from 'vite-plugin-cdn2'
 
 export default defineConfig({
   plugins: [
@@ -107,8 +107,12 @@ export default defineConfig({
         }
       ],
       preset: false,
-      transform(result) {
-        if (result.tag === 'script') result.defer = true
+      transform(results) {
+        results.forEach((result) => {
+          if (result.tag === 'script') {
+            result.defer = true
+          }
+        })
       }
     })
   ]

--- a/src/cdn-impl.ts
+++ b/src/cdn-impl.ts
@@ -186,8 +186,11 @@ export const cdn = (options: CDNPluginOptions = {}): Plugin => {
       const window = new Window()
       const { document } = window
       document.body.innerHTML = raw
-      const headEl = document.body.querySelector('head')
-      headEl.insertAdjacentHTML('beforeend', tpl)
+      // fix：调整cdn插入的位置，从head末尾移动到title标签之前，解决如果cdn的script加了defer属性，和页面module加载顺序的问题
+      // const headEl = document.body.querySelector('head')
+      // headEl.insertAdjacentHTML('beforeend', tpl)
+      const titleEl = document.body.querySelector('title')
+      titleEl.insertAdjacentHTML('beforebegin', tpl)
       return document.body.innerHTML
     }
   }


### PR DESCRIPTION
Fix the issue with the use of the "defer" attribute on scripts and the loading order of the page modules, as well as correct errors in the readme.

I want to add "defer" attribute on script, and when i build my program, I found the loading order with page modules was wrong. And there are some mistakes in the example that given in README.md.

I tried to fixed these problems and run the test and coverage, all of them were passed, so I created the pull request.