### PR TITLE
fix: package should work normal

### DIFF
--- a/__tests__/code-gen.spec.ts
+++ b/__tests__/code-gen.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 import { parse, traverse } from '@babel/core'
-import { createCodeGenerator } from '../dist/code-gen'
+import { createCodeGenerator } from '../src/code-gen'
 import { createScanner } from '../dist/scanner'
 import type { ModuleInfo } from '../src/interface'
 

--- a/__tests__/inject.spec.ts
+++ b/__tests__/inject.spec.ts
@@ -1,8 +1,8 @@
 import test from 'ava'
-import { len } from '../dist/shared'
-import { createInjectScript } from '../dist/inject'
-import { jsdelivr } from '../dist/url'
-import type { TrackModule } from '../dist'
+import { len } from '../src/shared'
+import { createInjectScript } from '../src/inject'
+import { jsdelivr } from '../src/url'
+import type { TrackModule } from '../src'
 
 interface MockIIFEMdoule extends TrackModule{
   relativeModule: string

--- a/__tests__/shared.spec.ts
+++ b/__tests__/shared.spec.ts
@@ -1,6 +1,6 @@
 import fsp from 'fs/promises'
 import test from 'ava'
-import { len, lookup } from '../dist/shared'
+import { len, lookup } from '../src/shared'
 
 
 test('len', (t) => {

--- a/__tests__/vm.spec.ts
+++ b/__tests__/vm.spec.ts
@@ -1,0 +1,32 @@
+import test from 'ava'
+import { MAX_CONCURRENT, createConcurrentQueue, createVM } from '../src/vm'
+
+test('native vm', async (t) => {
+  const vm = createVM()
+  await vm.run('var nonzzz = \'test plugin\'', { name: 'nonzzz' } as any, (err) => err)
+  t.is(vm.bindings.has('nonzzz'), true)
+})
+
+test('shadow vm', async (t) => {
+  const vm = createVM()
+  await vm.run('window.nonzzz = 123', { name: 'nonzzz' } as any, (err) => err)
+  t.is(vm.bindings.has('nonzzz'), true)
+})
+
+test('throw error in vm', async (t) => {
+  const vm = createVM()
+  await vm.run('throw new Error(\'error\')', { name: 'nonzzz' } as any, (err) => {
+    t.is(err?.message, 'nonzzz')
+  })
+})
+
+test('task queue', async (t) => {
+  const tasks = [() => Promise.resolve(), () => Promise.resolve(), () => Promise.reject(new Error('3'))]
+
+  const queue = createConcurrentQueue(MAX_CONCURRENT)
+  for (const task of tasks) {
+    queue.enqueue(task)
+  }
+  const err = await t.throwsAsync(queue.wait())
+  t.is(err?.message, '3')
+})

--- a/docs/URL.md
+++ b/docs/URL.md
@@ -4,7 +4,7 @@
 
 ```js
 import { cdn } from 'vite-plugin-cdn2'
-import { unpkg } from 'vite-plugin-cdn2/url'
+import { unpkg } from 'vite-plugin-cdn2/url.js'
 
 cdn({url:unpkg,modules:['vue']})
 

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-plugin-cdn2-example",
   "scripts": {
-    "dev": "vite",
+    "dev": "set DEBUG=vite-plugin-cdn2 & vite",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -4,7 +4,7 @@ import vue from '@vitejs/plugin-vue'
 import { VarletUIResolver } from 'unplugin-vue-components/resolvers'
 import Components from 'unplugin-vue-components/vite'
 import { cdn } from 'vite-plugin-cdn2'
-import { unpkg } from 'vite-plugin-cdn2/url'
+import { unpkg } from 'vite-plugin-cdn2/url.js'
 import { compression } from 'vite-plugin-compression2'
 import Inspect from 'vite-plugin-inspect'
 

--- a/package.json
+++ b/package.json
@@ -30,12 +30,17 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./url": {
+    "./url.js": {
       "types":"./dist/url.d.ts",
       "import": "./dist/url.mjs",
       "require": "./dist/url.js"
     },
     "./*": "./*"
+  },
+  "typesVersions": {
+    "*": {
+      "url.js": ["./dist/url.d.ts"]
+    }
   },
   "author": "Kanno",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -37,13 +37,6 @@
     },
     "./*": "./*"
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/*"
-      ]
-    }
-  },
   "author": "Kanno",
   "license": "MIT",
   "homepage": "https://github.com/nonzzz/vite-plugin-cdn",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "require": "./dist/index.js"
     },
     "./url.js": {
-      "types":"./dist/url.d.ts",
+      "types": "./dist/url.d.ts",
       "import": "./dist/url.mjs",
       "require": "./dist/url.js"
     },
@@ -39,7 +39,9 @@
   },
   "typesVersions": {
     "*": {
-      "url.js": ["./dist/url.d.ts"]
+      "url.js": [
+        "./dist/url.d.ts"
+      ]
     }
   },
   "author": "Kanno",
@@ -55,6 +57,7 @@
   "devDependencies": {
     "@rollup/plugin-json": "^6.0.0",
     "@types/babel__core": "^7.20.1",
+    "@types/debug": "^4.1.8",
     "ava": "^5.2.0",
     "c8": "^7.12.0",
     "eslint": "^8.23.1",
@@ -70,6 +73,7 @@
     "@babel/core": "^7.22.5",
     "@rollup/pluginutils": "^5.0.2",
     "@types/estree": "^1.0.1",
+    "debug": "^4.3.4",
     "happy-dom": "^6.0.4",
     "rs-module-lexer": "^1.0.0"
   },

--- a/src/code-gen.ts
+++ b/src/code-gen.ts
@@ -22,7 +22,7 @@ export class CodeGen {
     const modules = Array.from(new Set([...imports.map(i => i.n)]))
     for (const m of modules) {
       if (this.dependencies.has(m)) return true
-      return false
+      continue
     }
     return false
   }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -2,13 +2,17 @@ import fsp from 'fs/promises'
 import worker_threads from 'worker_threads'
 import type { MessagePort } from 'worker_threads'
 import { MAX_CONCURRENT, createConcurrentQueue, createVM } from './vm'
-import { is, len, lookup  } from './shared'
+import { _import, is, len, lookup } from './shared'
 import type { IIFEModuleInfo, IModule, ModuleInfo, ResolverFunction, TrackModule } from './interface'
 
 // This file is a simply dependencies scanner.
 // We won't throw any error unless it's an internal thread error(such as pid not equal)
 // we consume all expection modules in the plugin itself.
 // Notice. This file don't handle any logic with script inject.
+
+// TODO
+// We pack this file just to make the test pass. If we migrate to other test framework
+// Don't forget remove it.
 
 interface WorkerData {
     scannerModule: IModule[]
@@ -83,7 +87,7 @@ async function tryResolveModule(
       const code = await fsp.readFile(iifeFilePath, 'utf8')
       Object.assign(meta, { name, version, code, relativeModule: iifeRelativePath, ...rest })
     }
-    const pkg = await import(moduleName)
+    const pkg = await _import(moduleName)
     const keys = Object.keys(pkg)
     // If it's only exports by default
     if (keys.includes('default') && len(keys) !== 1) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -30,3 +30,7 @@ export function is(condit: boolean, message: string) {
     throw new Error(message)
   }
 }
+
+// TODO 
+// If we find the correct dynamic import handing it should be removed.
+export const _import = new Function('specifier', 'return import(specifier)')

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import type { Options } from 'tsup'
 
 export const tsup: Options = {
-  entry: ['src/*.ts'],
+  entry: ['src/index.ts', 'src/url.ts', 'src/scanner.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   splitting: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,6 +531,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debug@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
+  integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/estree@^1.0.0", "@types/estree@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
@@ -552,6 +559,11 @@
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "18.15.11"


### PR DESCRIPTION
# Background

After we migrate to `tsup`. It seem break previous behavior.
- `await import` has been transform. But we won't need it.
- `typesVersions` cause type error.
-  Fix `codeGen` filter logic.


#13 #12 
